### PR TITLE
example of using say as an extension

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,35 +1,5 @@
 require 'sinatra'
 require 'yaml'
 require 'ipaddr'
-
-class AinsleyTwo < Sinatra::Base
-  config = YAML.load_file('config.yml')
-  whitelist = YAML.load_file('whitelist.yml')
-
-  say = lambda do
-    if params && whitelist.include?(params[:token])
-      `say #{params[:words]}`
-    else
-      halt 403
-    end
-  end
-
-  get '/say', &say
-  post '/say', &say
-
-  # Return a key if the incoming request is from an internal network
-  # Save the key to the whitelist
-  get '/key' do
-    if subnet=config['subnet']
-      internal = IPAddr.new(subnet)
-      incoming = IPAddr.new(request.ip)
-      if internal.include?(incoming)
-        key = SecureRandom.hex
-        whitelist ||= []
-        whitelist.push(key)
-        File.open('config.yml', 'w') {|f| f.write(whitelist.to_yaml) }
-        key
-      end
-    end
-  end
-end
+require File.join(File.dirname(__FILE__), 'lib', 'ainsleytwo')
+require File.join(File.dirname(__FILE__), 'extensions', 'say')

--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,4 @@ Bundler.require
 
 require File.join(File.dirname(__FILE__), 'app')
 
-run AinsleyTwo
+run AinsleyTwo::Web

--- a/extensions/say.rb
+++ b/extensions/say.rb
@@ -1,0 +1,1 @@
+require File.join(File.dirname(__FILE__), 'say', 'say')

--- a/extensions/say/say.rb
+++ b/extensions/say/say.rb
@@ -1,0 +1,51 @@
+module Say
+  extend AinsleyTwo::Extension
+
+  def self.absorbable
+    [:web]
+  end
+
+  module Web
+    def self.absorb(app)
+      whitelist_path = File.join(AinsleyTwo.app_root, 'whitelist.yml')
+      if File.exist?(whitelist_path)
+        whitelist = YAML.load_file(whitelist_path)
+      else
+        whitelist = []
+      end
+      app.set(:whitelist, whitelist)
+
+      say = lambda do
+        if params && whitelist.include?(params[:token])
+          `say #{params[:words]}`
+        else
+          halt 403
+        end
+      end
+
+      app.get '/say', &say
+      app.post '/say', &say
+
+      # Return a key if the incoming request is from an internal network
+      # Save the key to the whitelist
+      app.get '/key' do
+        if subnet=settings.config['subnet']
+          internal = IPAddr.new(subnet)
+          incoming = IPAddr.new(request.ip)
+          if internal.include?(incoming)
+            key = SecureRandom.hex
+            settings.whitelist ||= []
+            settings.whitelist.push(key)
+            File.open('whitelist.yml', 'w+') do |f|
+              f.write(settings.whitelist.to_yaml)
+            end
+            # Return the key
+            key
+          end
+        end
+      end
+    end
+  end
+end
+
+AinsleyTwo.absorb(Say)

--- a/lib/ainsleytwo.rb
+++ b/lib/ainsleytwo.rb
@@ -1,0 +1,50 @@
+class AinsleyTwo
+
+  # Set required arguments for absorbable functionality
+  def self.functionality
+    {web: [Web]}
+  end
+  
+  # Register an extension
+  def self.absorb mod
+    # Iterate through each absorbable module, absorbing
+    # available functionality
+    mod.absorbable.each do |absorbable|
+      mod.absorbing(absorbable, functionality[absorbable])
+    end
+  end
+
+  # Extension helpers
+  module Extension
+    def absorbing(absorbable, functionality)
+      mod = Kernel.const_get(self.name.to_sym)
+      absorbable_name = absorbable.to_s.capitalize.to_sym
+      absorbable_mod = mod.const_get(absorbable_name)
+
+      # Extend respective AinsleyTwo extension
+      ainsley_class = AinsleyTwo.const_get(absorbable_name)
+      ainsley_class.extend(absorbable_mod)
+
+      absorbable_mod.absorb(*functionality)
+    end
+  end
+
+  # Load some configuration
+  def self.config
+    @config ||= YAML.load_file('config.yml')
+  end
+
+  # Set the application root directory
+  def self.app_root
+    File.join(File.dirname(__FILE__), '..')
+  end
+
+  # Sinatra support
+  class Web < Sinatra::Base
+    set :config, AinsleyTwo.config
+
+    get '/' do
+      'Hello. I am AinsleyTwo.'
+    end
+  end
+end


### PR DESCRIPTION
An example web extension for AinsleyTwo (Say).

Probably need some doco for this added to the PR, but I'll just type it into here for now:

```
# Writing an extension
class Hi
  extend AinsleyTwo::Extension

  # These are the classes (denoted by symbols) that you are going
  # to inject into AinsleyTwo
  def self.absorbables
    [:web]
  end

  module Web
    # This is the callback we're using to do more stuff
    # for AinsleyTwo.
    # AinsleyTwo will know what arguments to pass into
    # this callback based on the absorbable type.
    #
    # Here, app, is a Sinatra web app passed in by AinsleyTwo
    def self.absorb(app)
      app.get('/hi') do
        'hi'
      end
    end
  end
end

AinsleyTwo.absorb(Hi)
```
