### PR TITLE
use espeak for voice instead of relying on google translate service

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ Install audio player(s):
 Configure Pi to send audio out of the 3.5mm jack:
 
 `sudo amixer cset numid=3 1`
+
+Set audio volume:
+
+`amixer sset 'PCM' 90%`
+
+Install espeak for say command:
+
+`sudo apt-get install espeak`

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -21,4 +21,4 @@ sudo gem install bundler
 sudo apt-get install -y mpg123
 sudo apt-get install -y mplayer
 
-
+sudo apt-get install -y espeak

--- a/scripts/say
+++ b/scripts/say
@@ -1,2 +1,2 @@
 #!/bin/bash
-mplayer "http://translate.google.com/translate_tts?tl=en&q=$1";
+echo "$1" | espeak -ven-us+f3 -s120 -p50 2>/dev/null


### PR DESCRIPTION
at some point google translate caught on to the non-tos use of their voice service and started blocking requests to my poor ainsley. 

this uses the espeak library to produce sounds locally on the device with no external service dependency.
